### PR TITLE
Update custom resource runtime from 16 to 18

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -173,7 +173,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
       FunctionName: absoluteFunctionName,
       Handler,
       MemorySize: 1024,
-      Runtime: 'nodejs16.x',
+      Runtime: 'nodejs18.x',
       Timeout: 180,
     },
     DependsOn: [],

--- a/test/unit/lib/plugins/aws/customResources/index.test.js
+++ b/test/unit/lib/plugins/aws/customResources/index.test.js
@@ -109,7 +109,7 @@ describe('#addCustomResourceToService()', () => {
           Role: {
             'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
           },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 180,
         },
         DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -128,7 +128,7 @@ describe('#addCustomResourceToService()', () => {
           Role: {
             'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
           },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 180,
         },
         DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -147,7 +147,7 @@ describe('#addCustomResourceToService()', () => {
           Role: {
             'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
           },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 180,
         },
         DependsOn: ['IamRoleCustomResourcesLambdaExecution'],


### PR DESCRIPTION
- https://techfromsage.atlassian.net/browse/PLT-266

Bump custom resources from Node 16 to 18.

The branching strategy for this PR:

- We have forked the serverless repo 
- We have created a branch `talis_v2` from `v2`. This isn't strictly necessary - but will allow us to pull `v2` from `serverless` and then rebase `talis_v2` onto it locally. This is not strictly necessary, we could merge our PR's into `v2` in our fork.
- This PR merges our fix from the story branch into `talis_v2`
- Releases of applications using this fork will reference the `talis_v2` tag.